### PR TITLE
.NEO #upper"も55px分移動

### DIFF
--- a/dist/PaintBBS-1.5.5.js
+++ b/dist/PaintBBS-1.5.5.js
@@ -1029,10 +1029,10 @@ Neo.setToolSide = function(side) {
 	  Neo.addRule(".NEO #upper", "padding-right", "75px !important");
 	  
     } else {
-		Neo.addRule(".NEO #toolsWrapper", "right", "auto");
-		Neo.addRule(".NEO #toolsWrapper", "left", "0");
-		Neo.addRule(".NEO #painterWrapper", "padding", "0 0 0 55px !important");
-		Neo.addRule(".NEO #upper", "padding-right", "20px !important");
+	  Neo.addRule(".NEO #toolsWrapper", "right", "auto");
+	  Neo.addRule(".NEO #toolsWrapper", "left", "0");
+	  Neo.addRule(".NEO #painterWrapper", "padding", "0 0 0 55px !important");
+	  Neo.addRule(".NEO #upper", "padding-right", "20px !important");
     }
 };
 

--- a/dist/PaintBBS-1.5.5.js
+++ b/dist/PaintBBS-1.5.5.js
@@ -1025,11 +1025,14 @@ Neo.setToolSide = function(side) {
     if (!Neo.toolSide) {
       Neo.addRule(".NEO #toolsWrapper", "right", "0");
       Neo.addRule(".NEO #toolsWrapper", "left", "auto");
-      Neo.addRule(".NEO #painterWrapper", "padding", "0 55px 0 0 !important");
+	  Neo.addRule(".NEO #painterWrapper", "padding", "0 55px 0 0 !important");
+	  Neo.addRule(".NEO #upper", "padding-right", "75px !important");
+	  
     } else {
-      Neo.addRule(".NEO #toolsWrapper", "right", "auto");
-      Neo.addRule(".NEO #toolsWrapper", "left", "0");
-      Neo.addRule(".NEO #painterWrapper", "padding", "0 0 0 55px !important");
+		Neo.addRule(".NEO #toolsWrapper", "right", "auto");
+		Neo.addRule(".NEO #toolsWrapper", "left", "0");
+		Neo.addRule(".NEO #painterWrapper", "padding", "0 0 0 55px !important");
+		Neo.addRule(".NEO #upper", "padding-right", "20px !important");
     }
 };
 

--- a/dist/neo.js
+++ b/dist/neo.js
@@ -1029,10 +1029,10 @@ Neo.setToolSide = function(side) {
 	  Neo.addRule(".NEO #upper", "padding-right", "75px !important");
 	  
     } else {
-		Neo.addRule(".NEO #toolsWrapper", "right", "auto");
-		Neo.addRule(".NEO #toolsWrapper", "left", "0");
-		Neo.addRule(".NEO #painterWrapper", "padding", "0 0 0 55px !important");
-		Neo.addRule(".NEO #upper", "padding-right", "20px !important");
+	  Neo.addRule(".NEO #toolsWrapper", "right", "auto");
+	  Neo.addRule(".NEO #toolsWrapper", "left", "0");
+	  Neo.addRule(".NEO #painterWrapper", "padding", "0 0 0 55px !important");
+	  Neo.addRule(".NEO #upper", "padding-right", "20px !important");
     }
 };
 

--- a/dist/neo.js
+++ b/dist/neo.js
@@ -1025,11 +1025,14 @@ Neo.setToolSide = function(side) {
     if (!Neo.toolSide) {
       Neo.addRule(".NEO #toolsWrapper", "right", "0");
       Neo.addRule(".NEO #toolsWrapper", "left", "auto");
-      Neo.addRule(".NEO #painterWrapper", "padding", "0 55px 0 0 !important");
+	  Neo.addRule(".NEO #painterWrapper", "padding", "0 55px 0 0 !important");
+	  Neo.addRule(".NEO #upper", "padding-right", "75px !important");
+	  
     } else {
-      Neo.addRule(".NEO #toolsWrapper", "right", "auto");
-      Neo.addRule(".NEO #toolsWrapper", "left", "0");
-      Neo.addRule(".NEO #painterWrapper", "padding", "0 0 0 55px !important");
+		Neo.addRule(".NEO #toolsWrapper", "right", "auto");
+		Neo.addRule(".NEO #toolsWrapper", "left", "0");
+		Neo.addRule(".NEO #painterWrapper", "padding", "0 0 0 55px !important");
+		Neo.addRule(".NEO #upper", "padding-right", "20px !important");
     }
 };
 


### PR DESCRIPTION
".NEO #upper"の「やり直し」「もとに戻す」「塗り潰し」「右の箇所」も55px移動するようにしてみましたが…。
問題があるようでしたら見送りでお願いします。