### PR TITLE
CSS

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -744,7 +744,7 @@ Neo.createViewer = function (applet) {
   neo.id = "NEO";
 
   var html =
-    '<div id="pageView">' +
+    '<div id="pageView" style="margin:auto;">' +
     '<div id="container" style="visibility:visible;" class="o">' +
     '<div id="painter" style="background-color:white;">' +
     '<div id="canvas" style="background-color:white;">' +

--- a/src/neo.css
+++ b/src/neo.css
@@ -63,7 +63,7 @@
     right: 0;
 
     height:30px;
-    padding-right: 75px; //20px;
+	padding-right: 75px; /* 20px; */
     text-align:right;
 }
 
@@ -571,8 +571,8 @@
 
     margin: 0;
     padding: 0;
-    //padding-top: 2px;
-    //padding-left: 2px;
+    /* padding-top: 2px; */
+    /* padding-left: 2px; */
 
     overflow: hidden;
 }


### PR DESCRIPTION
### 動画が左端に寄る場合がある
![Screen-2020-06-24_00-14-32](https://user-images.githubusercontent.com/44894014/85424367-cc9f0080-b5b2-11ea-8e37-48065ad3221b.png)
![Screen-2020-06-24_00-13-51](https://user-images.githubusercontent.com/44894014/85424377-d0328780-b5b2-11ea-869d-995ba4e6280f.png)
掲示版側で対応可能な箇所は掲示版で…と思いましたがこれまでに配布したテンプレートをエンドユーザーが修正して対応…とはならない可能性が高いためプルリクしました。
```
<div id="pageView" style="margin: auto; width: 300px; height: 326px;">
1.5.6
<div id="pageView" style="width: 300px; height: 326px;">
1.5.7以後
```
掲示版のテンプレートによっては動画が左端によってしまいます。
### neo.css
次にneo.cssですが、　//　がエラーになり、minifyがうまくいきません。
minifyしたcssで問題がでてもそれはminifyした人の自己責任…だと思いますが、cssのエラーのようでしたのでプルリクさせていただきました。
問題がありましたらお知らせください。
お手数をおかけしますがよろしくおねがいします。