### PR TITLE
.NEO #toolsWrapper

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -1393,7 +1393,7 @@ Neo.setToolSide = function (side) {
     Neo.addRule(".NEO #upper", "padding-right", "75px !important");
   } else {
     Neo.addRule(".NEO #toolsWrapper", "right", "auto");
-    Neo.addRule(".NEO #toolsWrapper", "left", "-3px");
+    Neo.addRule(".NEO #toolsWrapper", "left", "-1px");
     Neo.addRule(".NEO #painterWrapper", "padding", "0 0 0 55px !important");
     Neo.addRule(".NEO #upper", "padding-right", "20px !important");
   }


### PR DESCRIPTION
ツールパレットを左に配置した状態でキャンバスを拡大すると、網のあるアプレットの領域からツールパレットが左側に約1.5pxはみだしてしまうようです。
各パーツの幅の合計で考えると-3pxが適切な筈ですが実際の画面ではうまくいきませんでした。
実用上問題ない箇所ですが、よろしくお願いいたします。

![200625_002](https://user-images.githubusercontent.com/44894014/85600065-160d4f80-b688-11ea-9101-f532f91333f8.png)
↑
ツールパレットが左に1.5pxはみ出した状態。
![200625_001](https://user-images.githubusercontent.com/44894014/85600106-20c7e480-b688-11ea-9b01-ad68a35710bb.png)
↑
`Neo.addRule(".NEO #toolsWrapper", "left", "-1px");`
に修正後。
問題がありましたらお知らせください。