### PR TITLE
POTI改

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ Chrome(80以降？)で横に長い線を引くとジェスチャーと誤認識�
 ## <a name="deploy">お絵かき掲示板の設置方法について</a>
 新しくお絵かき掲示板を設置したい方には、POTI-board改の利用をお勧めします。  
 
-- [POTI改公式サイト](https://pbbs.sakura.ne.jp/poti/)
+- [POTI改公式サイト](https://paintbbs.sakura.ne.jp/poti/)
 
-公式サイトには[設置サポート掲示板](https://pbbs.sakura.ne.jp/cgi/neosample/support/)があります。  
+公式サイトには[設置サポート掲示板](https://paintbbs.sakura.ne.jp/cgi/neosample/support/)があります。  
 掲示板の設置に関するご質問・不具合の報告等ありましたら、遠慮なくこちらへどうぞ。
 
 まだ古いPOTI-baordを稼働中の方のための[移行ガイド](README-potiboard.md)  


### PR DESCRIPTION
POTI改の設置サポート掲示板のurlが変更になりました。すくなくとも来年の9月まではリダイレクトがかかりますが、それ以後はリンク切れになる可能性があります。
新 url https://paintbbs.sakura.ne.jp/cgi/neosample/support/
プルリクでリンク変更のお願いをするべきか、別途書き込むべきか迷いましたが、プルリクによるリンク修正のリクエストを出してみました。
よろしくお願いいたします。