### PR TITLE
投稿に失敗した時のアラートにサーバーのError番号を追加。

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -1195,7 +1195,8 @@ Neo.submit = function (board, blob, thumbnail, thumbnail2) {
 
     var errorMessage = null;
     if (request.status / 100 != 2) {
-      errorMessage = request.responseURL + "\n"
+	errorMessage = "Error " + request.status + "\n" 
+	+ request.responseURL + "\n"
                    + Neo.translate("投稿に失敗。時間を置いて再度投稿してみてください。");
     } else if (request.response.match(/^error\n/m)) {
       errorMessage = request.response.replace(/^error\n/m, '');


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/44894014/171795771-2a333b82-d210-479c-9463-e732a43a5e0b.png)
ロリポップのWAFが攻撃と判断して投稿先のphpファイルを403に変更してエラーメッセージ｢時間を置いて再度投稿してみてください。｣が表示される事例がありました。
NEOのブラウザストレージからの復元を攻撃と認識してしまったケースです。

![image](https://user-images.githubusercontent.com/44894014/171796655-d2a150fb-8e58-4566-9c5a-e43093518eb7.png)

この時、エンドユーザーは｢時間を置いて再度投稿してみてください。｣が出るとだけ伝えて来ます。
サーバのレスポンスはChromeの開発者ツールのConsoleで確認できますが、開発者ツールの使い方を知らないエンドユーザーもいます。
そうなると、掲示板のURLがわかるまで、原因がわからなくなってしまいます。
そのため、403なのか、404なのか、503なのかアラートでわかるように該当箇所を書いてみました。　
