### PR TITLE
管理者による設定変の更が必要な403、404の時は、エラーメッセージにステータスを追加。回線が切断されている時にもエラーメッセージを追加。

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -1195,9 +1195,13 @@ Neo.submit = function (board, blob, thumbnail, thumbnail2) {
 
     var errorMessage = null;
     if (request.status / 100 != 2) {
-	errorMessage = "Error " + request.status + "\n" 
-	+ request.responseURL + "\n"
-                   + Neo.translate("投稿に失敗。時間を置いて再度投稿してみてください。");
+    if (request.status == 403) {
+        errorMessage = "403 forbidden\n";
+        } else if (request.status == 404) {
+            errorMessage = "404 not found\n";
+        }
+        errorMessage = errorMessage + request.responseURL + "\n" +
+        Neo.translate("投稿に失敗。時間を置いて再度投稿してみてください。");
     } else if (request.response.match(/^error\n/m)) {
       errorMessage = request.response.replace(/^error\n/m, '');
     } else {
@@ -1232,10 +1236,13 @@ Neo.submit = function (board, blob, thumbnail, thumbnail2) {
     Neo.submitButton.enable();
   };
   request.ontimeout = function (e) {
+    var errorMessage = null;
+    errorMessage = Neo.translate("投稿に失敗。時間を置いて再度投稿してみてください。");
+    alert(errorMessage);
     console.log("timeout");
     Neo.submitButton.enable();
   };
-
+  request.setRequestHeader("X-Requested-With", "PaintBBS");
   request.send(body);
 };
 

--- a/src/container.js
+++ b/src/container.js
@@ -1228,6 +1228,8 @@ Neo.submit = function (board, blob, thumbnail, thumbnail2) {
     }
   };
   request.onerror = function (e) {
+    var errorMessage = null;
+    errorMessage = Neo.translate("投稿に失敗。時間を置いて再度投稿してみてください。");
     console.log("error");
     Neo.submitButton.enable();
   };
@@ -1236,8 +1238,6 @@ Neo.submit = function (board, blob, thumbnail, thumbnail2) {
     Neo.submitButton.enable();
   };
   request.ontimeout = function (e) {
-    var errorMessage = null;
-    errorMessage = Neo.translate("投稿に失敗。時間を置いて再度投稿してみてください。");
     alert(errorMessage);
     console.log("timeout");
     Neo.submitButton.enable();

--- a/src/container.js
+++ b/src/container.js
@@ -1195,13 +1195,15 @@ Neo.submit = function (board, blob, thumbnail, thumbnail2) {
 
     var errorMessage = null;
     if (request.status / 100 != 2) {
+    errorMessage = request.responseURL + "\n";
     if (request.status == 403) {
-        errorMessage = "403 forbidden\n";
+        errorMessage = errorMessage + Neo.translate("投稿に失敗。\nWAFの誤検知かもしれません。\nもう少し描いてみてください。");
         } else if (request.status == 404) {
-            errorMessage = "404 not found\n";
+        errorMessage = errorMessage + Neo.translate("ファイルが見当たりません。");
+        } else {
+        errorMessage = errorMessage + 
+        + Neo.translate("投稿に失敗。時間を置いて再度投稿してみてください。");
         }
-        errorMessage = errorMessage + request.responseURL + "\n" +
-        Neo.translate("投稿に失敗。時間を置いて再度投稿してみてください。");
     } else if (request.response.match(/^error\n/m)) {
       errorMessage = request.response.replace(/^error\n/m, '');
     } else {

--- a/src/dictionary.js
+++ b/src/dictionary.js
@@ -57,6 +57,9 @@ Neo.dictionary = {
     鈍: "L",
     "投稿に失敗。時間を置いて再度投稿してみてください。":
       "Please push send button again.",
+    "投稿に失敗。\nWAFの誤検知かもしれません。\nもう少し描いてみてください。":
+      "It may be a WAF false positive.\nTry to draw a little more.",
+    "ファイルが見当たりません。":"File not found",
   },
   enx: {
     やり直し: "Redo",
@@ -115,7 +118,10 @@ Neo.dictionary = {
     鈍: "L",
     "投稿に失敗。時間を置いて再度投稿してみてください。":
       "Failed to upload image. please try again.",
-  },
+    "投稿に失敗。\nWAFの誤検知かもしれません。\nもう少し描いてみてください。":
+      "It may be a WAF false positive.\nTry to draw a little more.",
+    "ファイルが見当たりません。":"File not found.",
+ },
   es: {
     やり直し: "Rehacer",
     元に戻す: "Deshacer",
@@ -173,6 +179,9 @@ Neo.dictionary = {
     鈍: "L",
     "投稿に失敗。時間を置いて再度投稿してみてください。":
       "No se pudo cargar la imagen. por favor, inténtalo de nuevo.",
+    "投稿に失敗。\nWAFの誤検知かもしれません。\nもう少し描いてみてください。":
+	  "Puede ser un falso positivo de WAF.\nIntenta dibujar un poco más.",
+    "ファイルが見当たりません。":"Archivo no encontrado.",
   },
 };
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/44894014/205899299-a9bad7e2-2fe8-41a3-87fe-416b29bba884.png)
funigeさんの開発方針と一致しているのかどうかがとても気になりましたが、自分なりに考えてみて必要だと思った箇所を再度プルリクさせていただきました。

(以下はissuesに記載の内容と同じです)

## NEOの復元機能をWAFが攻撃とみなす問題
NEOの復元機能を使った時に、ロリポップのWAFがPHPのデータ受信ファイルを403に変更してエラーになる問題がありますが、エラーメッセージに503エラーである事は表示されないので、以下のような問い合わせ内容になってしまいます。

> どうしても
> 投稿に失敗時間を置いて再度投稿してみてください。
> と出て描いたイラストが投稿できません…
> この場合どこを直せば良いのでしょうか
> 

この時、エラーメッセージに403と表示されていればレンタルサーバのマニュアルにしたがって自己解決が可能になります。

[403 Errorというエラーが発生します – ロリポップ！レンタルサーバー](https://support.lolipop.jp/hc/ja/articles/360049132833-403-Error%E3%81%A8%E3%81%84%E3%81%86%E3%82%A8%E3%83%A9%E3%83%BC%E3%81%8C%E7%99%BA%E7%94%9F%E3%81%97%E3%81%BE%E3%81%99)

[PHPやCGIでプログラムの記述変更をしたところ403errorが表示されます – ロリポップ！レンタルサーバー](https://support.lolipop.jp/hc/ja/articles/360048375814)

## 通信回線が切れている時にエラーメッセージが表示されない

そして、先日、追加の課題が発生しました。
別issueにするべきだったのかもしれませんが、ここにまとめさせていだだきます。

Wi-Fiなどの通信回線が不安定な状態で投稿ボタンを押下→ボタンを押したあとエラーメッセージがでないので、待機。
待機しても投稿が完了しないけれど、今の状態がわからないという事例がありました。
現在の設定では、通信回線が切断されている時はコンソールにエラーメッセージがでるのみですので、エンドユーザーに投稿に失敗した事がわからず、再度投稿ボタンを押すべきなのか待機するべきなのかわかりにくくなっているようです。

もちろん、それはまれな例なのかもしれませんが、通信回線が切れていてエラーになった時はエラーのアラートが開いたほうがいいと思いました。

## setRequestHeader
XHRまたはfetch等のAjaxからの投稿のみを許可する設定を受信するPHPなどのプログラムで設定可能にするカスタムヘッダの追加を検討していただけないでしょうか?
考え方の違いが出てくる可能性の高い箇所ですが、この箇所もプルリクエストに含めました。

`  request.setRequestHeader("X-Requested-With", "PaintBBS");
`
値に、headers: {'X-Requested-With': 'XMLHttpRequest'}のように`XMLHttpRequest`を使う事が多いようですが、`XMLHttpRequest`からfetchに今後は切り替わりそうな感じですので、値に`PaintBBS`と入れました。

```
// 拡張子設定
if($h=='S'){
	if(!strstr($u_agent,'Shi-Painter/')){
		unlink($full_imgfile);
		error("UA error。画像は保存されません。");
		exit;
	}
	$ext = '.spch';
}else{
	if(!strstr($u_agent,'PaintBBS/')){
		unlink($full_imgfile);
		error("UA error。画像は保存されません。");
		exit;
	}
	$ext = '.pch';
}

```
古いPOTI-boardとJavaAppletの時代には、UAで`PaintBBS/`からの投稿かどうか確認できていましたが、そのチェック機能を今は使用できないため、カスタムヘッダによる認証をしたいという事になります。

プルリクの実績をあげたいというよりも、独自規格ではなく統一規格で解決が可能な事は、意見交換をした上で解決したいという趣旨になります。
ご意見をお聞かせいただけるようでしたら幸いです。