### PR TITLE
WAFに攻撃と判断されないようにするため、formDataで個別にデータを送信するオプションを追加。

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -976,19 +976,20 @@ Neo.getFilename = function () {
 Neo.getPCH = function (filename, callback) {
   if (!filename || filename.slice(-4).toLowerCase() != ".pch") return null;
 
-  var request = new XMLHttpRequest();
-  request.open("GET", filename, true);
-  request.responseType = "arraybuffer";
-  request.onload = function () {
-    var pch = Neo.decodePCH(request.response);
+  fetch(filename)
+  .then(response => response.arrayBuffer())
+  .then(buffer => {
+    var pch = Neo.decodePCH(buffer);
     if (pch) {
       if (callback) callback(pch);
     } else {
       console.log("not a NEO animation");
     }
-  };
-  request.send();
-};
+  })
+  .catch(error => {
+    console.log(error);
+  });
+}
 
 Neo.decodePCH = function (rawdata) {
   var byteArray = new Uint8Array(rawdata);

--- a/src/container.js
+++ b/src/container.js
@@ -569,12 +569,12 @@ Neo.backgroundImage = function () {
 };
 
 Neo.multColor = function (c, scale) {
-  var r = Math.round(parseInt(c.substr(1, 2), 16) * scale);
-  var g = Math.round(parseInt(c.substr(3, 2), 16) * scale);
-  var b = Math.round(parseInt(c.substr(5, 2), 16) * scale);
-  r = ("0" + Math.min(Math.max(r, 0), 255).toString(16)).substr(-2);
-  g = ("0" + Math.min(Math.max(g, 0), 255).toString(16)).substr(-2);
-  b = ("0" + Math.min(Math.max(b, 0), 255).toString(16)).substr(-2);
+  var r = Math.round(parseInt(c.substring(1, 3), 16) * scale);
+  var g = Math.round(parseInt(c.substring(3, 5), 16) * scale);
+  var b = Math.round(parseInt(c.substring(5, 7), 16) * scale);
+  r = ("0" + Math.min(Math.max(r, 0), 255).toString(16)).slice(-2);
+  g = ("0" + Math.min(Math.max(g, 0), 255).toString(16)).slice(-2);
+  b = ("0" + Math.min(Math.max(b, 0), 255).toString(16)).slice(-2);
   return "#" + r + g + b;
 };
 

--- a/src/container.js
+++ b/src/container.js
@@ -1159,6 +1159,19 @@ Neo.submit = function (board, blob, thumbnail, thumbnail2) {
       }
     }
   }
+  if (Neo.config.neo_send_with_formdata == "true") {
+
+	var formData = new FormData();
+	formData.append('header', headerString);
+	formData.append('picture',blob,blob);
+
+	if (thumbnail) {
+		formData.append('thumbnail',thumbnail,blob);
+	  }
+	  if (thumbnail2) {
+		formData.append('pch',thumbnail2,blob);
+	}
+  }
   // console.log("submit url=" + url + " header=" + headerString);
 
   var header = new Blob([headerString]);
@@ -1245,7 +1258,11 @@ Neo.submit = function (board, blob, thumbnail, thumbnail2) {
     Neo.submitButton.enable();
   };
   request.setRequestHeader("X-Requested-With", "PaintBBS");
+  if (Neo.config.neo_send_with_formdata == "true") {
+	request.send(formData);
+  }else{
   request.send(body);
+  }
 };
 
 /*

--- a/src/painter.js
+++ b/src/painter.js
@@ -275,7 +275,9 @@ Neo.Painter.prototype._initCanvas = function (div, width, height) {
     this.canvas[i] = document.createElement("canvas");
     this.canvas[i].width = width;
     this.canvas[i].height = height;
-    this.canvasCtx[i] = this.canvas[i].getContext("2d");
+    this.canvasCtx[i] = this.canvas[i].getContext("2d",{
+		willReadFrequently: true,
+	});
 
     this.canvas[i].style.imageRendering = "pixelated";
     this.canvasCtx[i].imageSmoothingEnabled = false;
@@ -286,7 +288,9 @@ Neo.Painter.prototype._initCanvas = function (div, width, height) {
   this.tempCanvas = document.createElement("canvas");
   this.tempCanvas.width = width;
   this.tempCanvas.height = height;
-  this.tempCanvasCtx = this.tempCanvas.getContext("2d");
+  this.tempCanvasCtx = this.tempCanvas.getContext("2d",{
+		willReadFrequently: true,
+	});
   this.tempCanvas.style.position = "absolute";
   this.tempCanvas.enabled = false;
 
@@ -298,7 +302,9 @@ Neo.Painter.prototype._initCanvas = function (div, width, height) {
     this.container.appendChild(this.destCanvas);
   }
 
-  this.destCanvasCtx = this.destCanvas.getContext("2d");
+  this.destCanvasCtx = this.destCanvas.getContext("2d",{
+		willReadFrequently: true,
+	});
   this.destCanvas.width = destWidth;
   this.destCanvas.height = destHeight;
 
@@ -1023,7 +1029,9 @@ Neo.Painter.prototype.getImage = function (imageWidth, imageHeight) {
   var pngCanvas = document.createElement("canvas");
   pngCanvas.width = imageWidth;
   pngCanvas.height = imageHeight;
-  var pngCanvasCtx = pngCanvas.getContext("2d");
+  var pngCanvasCtx = pngCanvas.getContext("2d",{
+		willReadFrequently: true,
+	});
   pngCanvasCtx.fillStyle = "#ffffff";
   pngCanvasCtx.fillRect(0, 0, imageWidth, imageHeight);
 

--- a/src/painter.js
+++ b/src/painter.js
@@ -745,34 +745,6 @@ Neo.Painter.prototype._beforeUnloadHandler = function (e) {
    return this.stab;
    };
  */
-function isPinchZooming () {//ピンチズームを検知
-	if ('visualViewport' in window) {
-		return window.visualViewport.scale > 1
-	} else {
-		return document.documentElement.clientWidth > window.innerWidth
-	}
-}
-
-function neo_disable_touch_move (e) {//NEOの網目でスワイプしない
-	if (typeof e.cancelable !== 'boolean' || e.cancelable) {
-	e.preventDefault();
-	e.stopPropagation();
-	}
-}
-
-function neo_add_disable_touch_move() {
-	document.getElementById('NEO').addEventListener('touchmove', neo_disable_touch_move ,{ passive: false });
-}
-function neo_remove_disable_touch_move() {
-	document.getElementById('NEO').removeEventListener('touchmove', neo_disable_touch_move ,{ passive: false });
-}
-document.addEventListener('touchmove', function(e) {
-	neo_add_disable_touch_move();
-	if(isPinchZooming ()){//ピンチズーム使用時はNEOの網目でスワイプする
-		neo_remove_disable_touch_move();
-	}
-});
-window.addEventListener('DOMContentLoaded',neo_add_disable_touch_move,false);
 
 /*
    -------------------------------------------------------------------------

--- a/src/painter.js
+++ b/src/painter.js
@@ -481,20 +481,20 @@ Neo.Painter.prototype._keyDownHandler = function (e) {
   this.isShiftDown = e.shiftKey;
   this.isCtrlDown = e.ctrlKey;
   this.isAltDown = e.altKey;
-  if (e.keyCode == 32) this.isSpaceDown = true;
-
+  var key=e.key.toLowerCase();
+  if (key === ' ') this.isSpaceDown = true;
+  
   if (!this.isShiftDown && this.isCtrlDown) {
-    if (!this.isAltDown) {
-      if (e.keyCode == 90 || e.keyCode == 85) this.undo(); //Ctrl+Z,Ctrl.U
-      if (e.keyCode == 89) this.redo(); //Ctrl+Y
-    } else {
-      if (e.keyCode == 90) this.redo(); //Ctrl+Alt+Z
-    }
+	if (!this.isAltDown) {
+	  if (key === 'z' || key === 'u') this.undo(); // Ctrl+Z, Ctrl+U
+	  if (key === 'y') this.redo(); // Ctrl+Y
+	} else {
+	  if (key === 'z') this.redo(); // Ctrl+Alt+Z
+	}
   }
-
   if (!this.isShiftDown && !this.isCtrlDown && !this.isAltDown) {
-    if (e.keyCode == 107) new Neo.ZoomPlusCommand(this).execute(); // +
-    if (e.keyCode == 109) new Neo.ZoomMinusCommand(this).execute(); // -
+    if (key == '+') new Neo.ZoomPlusCommand(this).execute(); // +
+    if (key == '-') new Neo.ZoomMinusCommand(this).execute(); // -
   }
 
   if (this.tool.keyDownHandler) {
@@ -516,7 +516,7 @@ Neo.Painter.prototype._keyUpHandler = function (e) {
   this.isShiftDown = e.shiftKey;
   this.isCtrlDown = e.ctrlKey;
   this.isAltDown = e.altKey;
-  if (e.keyCode == 32) this.isSpaceDown = false;
+  if (e.key == ' ') this.isSpaceDown = false;
 
   if (this.tool.keyUpHandler) {
     this.tool.keyUpHandler(oe);
@@ -739,6 +739,34 @@ Neo.Painter.prototype._beforeUnloadHandler = function (e) {
    return this.stab;
    };
  */
+function isPinchZooming () {//ピンチズームを検知
+	if ('visualViewport' in window) {
+		return window.visualViewport.scale > 1
+	} else {
+		return document.documentElement.clientWidth > window.innerWidth
+	}
+}
+
+function neo_disable_touch_move (e) {//NEOの網目でスワイプしない
+	if (typeof e.cancelable !== 'boolean' || e.cancelable) {
+	e.preventDefault();
+	e.stopPropagation();
+	}
+}
+
+function neo_add_disable_touch_move() {
+	document.getElementById('NEO').addEventListener('touchmove', neo_disable_touch_move ,{ passive: false });
+}
+function neo_remove_disable_touch_move() {
+	document.getElementById('NEO').removeEventListener('touchmove', neo_disable_touch_move ,{ passive: false });
+}
+document.addEventListener('touchmove', function(e) {
+	neo_add_disable_touch_move();
+	if(isPinchZooming ()){//ピンチズーム使用時はNEOの網目でスワイプする
+		neo_remove_disable_touch_move();
+	}
+});
+window.addEventListener('DOMContentLoaded',neo_add_disable_touch_move,false);
 
 /*
    -------------------------------------------------------------------------
@@ -975,7 +1003,7 @@ Neo.Painter.prototype.dataURLtoBlob = function (dataURL) {
   if (dataURL.split(",")[0].indexOf("base64") >= 0) {
     byteString = atob(dataURL.split(",")[1]);
   } else {
-    byteString = unescape(dataURL.split(",")[1]);
+    byteString = decodeURI(dataURL.split(",")[1]);
   }
 
   // write the bytes of the string to a typed array
@@ -1200,15 +1228,15 @@ Neo.Painter.prototype.getBound = function (x0, y0, x1, y1, r) {
 
 Neo.Painter.prototype.getColor = function (c) {
   if (!c) c = this.foregroundColor;
-  var r = parseInt(c.substr(1, 2), 16);
-  var g = parseInt(c.substr(3, 2), 16);
-  var b = parseInt(c.substr(5, 2), 16);
+  var r = parseInt(c.substring(1, 3), 16);
+  var g = parseInt(c.substring(3, 5), 16);
+  var b = parseInt(c.substring(5, 7), 16);
   var a = Math.floor(this.alpha * 255);
   return (a << 24) | (b << 16) | (g << 8) | r;
 };
 
 Neo.Painter.prototype.getColorString = function (c) {
-  var rgb = ("000000" + (c & 0xffffff).toString(16)).substr(-6);
+  var rgb = ("000000" + (c & 0xffffff).toString(16)).slice(-6);
   return "#" + rgb;
 };
 
@@ -1256,14 +1284,14 @@ Neo.Painter.prototype.getAlpha = function (type) {
 };
 
 Neo.Painter.prototype.prepareDrawing = function () {
-  var r = parseInt(this.foregroundColor.substr(1, 2), 16);
-  var g = parseInt(this.foregroundColor.substr(3, 2), 16);
-  var b = parseInt(this.foregroundColor.substr(5, 2), 16);
+  var r = parseInt(this.foregroundColor.substring(1, 3), 16);
+  var g = parseInt(this.foregroundColor.substring(3, 5), 16);
+  var b = parseInt(this.foregroundColor.substring(5, 7), 16);
   var a = Math.floor(this.alpha * 255);
 
-  var maskR = parseInt(this.maskColor.substr(1, 2), 16);
-  var maskG = parseInt(this.maskColor.substr(3, 2), 16);
-  var maskB = parseInt(this.maskColor.substr(5, 2), 16);
+  var maskR = parseInt(this.maskColor.substring(1, 3), 16);
+  var maskG = parseInt(this.maskColor.substring(3, 5), 16);
+  var maskB = parseInt(this.maskColor.substring(5, 7), 16);
 
   this._currentColor = [r, g, b, a];
   this._currentMask = [maskR, maskG, maskB];

--- a/src/tools.js
+++ b/src/tools.js
@@ -459,7 +459,7 @@ Neo.DrawToolBase.prototype.bezierUpMoveHandler = function (oe) {
 };
 
 Neo.DrawToolBase.prototype.bezierKeyDownHandler = function (e) {
-  if (e.keyCode == 27) {
+  if (e.key == 'Escape') {
     //Escでキャンセル
     this.step = 0;
 
@@ -1158,7 +1158,7 @@ Neo.PasteTool.prototype.moveHandler = function (oe) {
 };
 
 Neo.PasteTool.prototype.keyDownHandler = function (e) {
-  if (e.keyCode == 27) {
+  if (e.key == 'Escape') {
     //Escでキャンセル
     var oe = Neo.painter;
     oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
@@ -1300,7 +1300,7 @@ Neo.TextTool.prototype.rollOverHandler = function (oe) {};
 Neo.TextTool.prototype.rollOutHandler = function (oe) {};
 
 Neo.TextTool.prototype.keyDownHandler = function (e) {
-  if (e.keyCode == 13) {
+  if (e.key == 'Enter') {
     // Returnで確定
     e.preventDefault();
 

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -431,7 +431,9 @@ Neo.ToolTip.prototype.update = function () {};
 Neo.ToolTip.prototype.draw = function (c) {
   if (this.hasTintImage) {
     if (typeof c != "string") c = Neo.painter.getColorString(c);
-    var ctx = this.canvas.getContext("2d");
+    var ctx = this.canvas.getContext("2d",{
+		willReadFrequently: true,
+	});
 
     if (this.prevMode != this.mode) {
       this.prevMode = this.mode;
@@ -604,7 +606,9 @@ Neo.Pen2Tip.prototype.update = function () {
 };
 
 Neo.Pen2Tip.prototype.drawTone = function () {
-  var ctx = this.canvas.getContext("2d");
+  var ctx = this.canvas.getContext("2d",{
+		willReadFrequently: true,
+	});
 
   var imageData = ctx.getImageData(0, 0, 46, 18);
   var buf32 = new Uint32Array(imageData.data.buffer);
@@ -677,7 +681,9 @@ Neo.EraserTip.prototype.update = function () {
 };
 
 Neo.EraserTip.prototype.draw = function () {
-  var ctx = this.canvas.getContext("2d");
+  var ctx = this.canvas.getContext("2d",{
+		willReadFrequently: true,
+	});
   ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
   var img = new Image();
 
@@ -842,7 +848,9 @@ Neo.MaskTip.prototype.update = function () {
 Neo.MaskTip.prototype.draw = function (c) {
   if (typeof c != "string") c = Neo.painter.getColorString(c);
 
-  var ctx = this.canvas.getContext("2d");
+  var ctx = this.canvas.getContext("2d",{
+		willReadFrequently: true,
+	});
   ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
   ctx.fillStyle = c;
   ctx.fillRect(1, 1, 43, 9);
@@ -1394,7 +1402,9 @@ Neo.ViewerButton.prototype.init = function (name, params) {
   if (name != "viewerSpeed") {
     this.element.innerHTML = "<canvas width=24 height=24></canvas>";
     this.canvas = this.element.getElementsByTagName("canvas")[0];
-    var ctx = this.canvas.getContext("2d");
+    var ctx = this.canvas.getContext("2d",{
+		willReadFrequently: true,
+	});
 
     var img = new Image();
     img.src = Neo.ViewerButton[name.toLowerCase().replace(/viewer/, "")];


### PR DESCRIPTION
## WAF誤検知のアラート実装後
WAF誤検知時のアラート実装のプルリクのマージ、ありがとうございました。
それによりアラートで、｢もう少し描いてみてください｣と表示する事でWAFにある程度対応できると思っていたのですが、  
少し描けばいいのなら｢描いて消してを繰り返してみよう｣方もいて、結果的に同じ画像になりWAFにって遮断されたままあきらめてしまうといった事例がでてきてしまいました。

[[591] PaintBBSの投稿画面切り替え時の不具合の件 - POTI改 設置サポート掲示板](https://paintbbs.sakura.ne.jp/cgi/neosample/support/potiboard.php?res=591)

## 生データの送信をformDataに変更

WAFをオフにすればいいのではと思われるかもしれませんが、SQLインジェクション、ディレクトリトラバーサルなどの攻撃がサイト上に多数確認されており、解除できそうにありません。
NEOの使用をあきらめるという選択肢も一度は考えたのですが、生データの送受信がWAFの誤検知の原因なのではないかという仮説をたてて検証してみました。

何度投稿してもWAFで攻撃と判断されるpch動画データを投稿して、キャンバスに読み込んで送信してみました。
ヘッダーのテキスト、画像、pchをそれぞれformDataに追加して、送信したところ、これまでWAFに検知されていた動画データからの投稿が問題なくできました。

また、2分以内の投稿はエラー `error\n描画時間が短すぎます`というアラートを出すようにして検証しました。
従来の生データの送受信であれば2分以内に、10回はWAFに攻撃と判断されていました。
しかし、formDataの場合は、WAFがオンでも問題なく投稿できました。

## formDataを使った送信のオプション

オプションで、formDataを使うか、従来通り生データで送信するかを選択できるようにしてみました。

`<param name="neo_send_with_formdata" value="true">`

の時は、生データではなくformDataを使う送信になります。

## formのname

拡張ヘッダ ''header''
PHPで受信するなら
`filter_input(INPUT_POST,'header',);`
(描画時間や作画工程数なども従来通り取り出す事ができる事を確認済み)
投稿されるPNG画像 'picture' 
PHPで受信するなら
`$_FILES['picture']['tmp_name']`
PCHファイル
'pch'
PHPで受信するなら
`$_FILES['pch']['tmp_name']`
サムネイル 'thumbnail'
PHPで受信するなら
`$_FILES['thumbnail']['tmp_name']`

運営サイトでは、この独自仕様版ですでに運用中ですが、その他のPOTI-boardほかのエンドユーザーの方からも、WAFに関する投稿エラーの問い合わせがあり、その対応も必要になっています。

開発の原点である、ふたばでは問題がでていない事になり申し訳ないのですが、ご検討いただければ幸いです。
よろしくお願いいたします。