### PR TITLE
エラーメッセージに未定義の変数が入っていたのを修正。

### DIFF
--- a/sample/sample_handler.php
+++ b/sample/sample_handler.php
@@ -55,7 +55,7 @@ if(isset($_FILES['pch']) && ($_FILES['pch']['error'] == UPLOAD_ERR_OK)){
 // 情報データをファイルに書き込む
 file_put_contents(SAVE_DIR.$imgfile.".dat",$userdata,LOCK_EX);
 if(!is_file(SAVE_DIR.$imgfile.'.dat')){
-	die("error\n{$errormsg_1}");
+	die("error\nYour picture upload failed! Please try again!");
 }
 chmod(SAVE_DIR.$imgfile.'.dat',PERMISSION_FOR_LOG);
 


### PR DESCRIPTION
こちらのミスでエラーメッセージに未定義の変数が入ってしまっていたのを修正しました。
お手数をおかけしますが、よろしくお願い致します。