### PR TITLE
回線が切断されている時に表示されるエラーメッセージ

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -1243,6 +1243,7 @@ Neo.submit = function (board, blob, thumbnail, thumbnail2) {
 				return location.href = exitURL;
 				})
 			}else{
+				Neo.submitButton.enable();
 				let response_status = response.status; 
 				if (response_status == 403) {
 
@@ -1257,9 +1258,9 @@ Neo.submit = function (board, blob, thumbnail, thumbnail2) {
 			}
 		})
 		.catch((error) => {
-			alert(errorMessage + 
-			+ Neo.translate("投稿に失敗。時間を置いて再度投稿してみてください。"));
-		Neo.submitButton.enable();
+			Neo.submitButton.enable();
+			//回線が切断されている時には翻訳されず`NaN`になるため英語版のエラーメッセージ
+			return alert(errorMessage + "Please push send button again.");
 		})
 	}
 

--- a/src/container.js
+++ b/src/container.js
@@ -1253,14 +1253,14 @@ Neo.submit = function (board, blob, thumbnail, thumbnail2) {
 				return alert(errorMessage + Neo.translate("ファイルが見当たりません。"));
 				}
 				return alert(errorMessage + 
-				+ Neo.translate("投稿に失敗。時間を置いて再度投稿してみてください。"));
+				Neo.translate("投稿に失敗。時間を置いて再度投稿してみてください。"));
 
 			}
 		})
 		.catch((error) => {
 			Neo.submitButton.enable();
-			//回線が切断されている時には翻訳されず`NaN`になるため英語版のエラーメッセージ
-			return alert(errorMessage + "Please push send button again.");
+			alert(errorMessage + 
+				Neo.translate("投稿に失敗。時間を置いて再度投稿してみてください。"));
 		})
 	}
 

--- a/src/container.js
+++ b/src/container.js
@@ -1259,7 +1259,7 @@ Neo.submit = function (board, blob, thumbnail, thumbnail2) {
 		})
 		.catch((error) => {
 			Neo.submitButton.enable();
-			alert(errorMessage + 
+			return alert(errorMessage + 
 				Neo.translate("投稿に失敗。時間を置いて再度投稿してみてください。"));
 		})
 	}


### PR DESCRIPTION
```
.catch((error) => {
			Neo.submitButton.enable();
			//回線が切断されている時には翻訳されず`NaN`になるため英語版のエラーメッセージ
			return alert(errorMessage + "Please push send button again.");
		})

```
回線が切れていたり、Apacheが起動していない時のエラーメッセージが翻訳されず`NaN`になる事がわかりましたので、英語版のエラーメッセージに差し換えました。
このエラーメッセージが出たあとでもApacheを再起動すれば投稿できます。
エラーメッセージの表示のalertを、他の箇所にあわせてreturn alert()にしました。
確認不足でした。
お手数をおかけしますがよろしくお願いします。