### PR TITLE
オリジナルのPaintBBSと同じように、描画中に円カーソルを表示したままにする

### DIFF
--- a/src/tools.js
+++ b/src/tools.js
@@ -236,7 +236,7 @@ Neo.DrawToolBase.prototype.freeHandDownHandler = function (oe) {
     var rect = oe.getBound(oe.mouseX, oe.mouseY, oe.mouseX, oe.mouseY, r);
     oe.updateDestCanvas(rect[0], rect[1], rect[2], rect[3], true);
   }
-  if (navigator.maxTouchPoints < 2){
+  if (!Neo.isMobile()){
 	this.drawCursor(oe);
   }
 };
@@ -273,7 +273,7 @@ Neo.DrawToolBase.prototype.freeHandMoveHandler = function (oe) {
   var r = Math.ceil(oe.lineWidth / 2);
   var rect = oe.getBound(oe.mouseX, oe.mouseY, oe.prevMouseX, oe.prevMouseY, r);
   oe.updateDestCanvas(rect[0], rect[1], rect[2], rect[3], true);
-  if (navigator.maxTouchPoints < 2){
+  if (!Neo.isMobile()){
 	this.drawCursor(oe);
   }
 };

--- a/src/tools.js
+++ b/src/tools.js
@@ -236,7 +236,9 @@ Neo.DrawToolBase.prototype.freeHandDownHandler = function (oe) {
     var rect = oe.getBound(oe.mouseX, oe.mouseY, oe.mouseX, oe.mouseY, r);
     oe.updateDestCanvas(rect[0], rect[1], rect[2], rect[3], true);
   }
-  this.drawCursor(oe);
+  if (navigator.maxTouchPoints < 2){
+	this.drawCursor(oe);
+  }
 };
 
 Neo.DrawToolBase.prototype.freeHandUpHandler = function (oe) {
@@ -271,7 +273,9 @@ Neo.DrawToolBase.prototype.freeHandMoveHandler = function (oe) {
   var r = Math.ceil(oe.lineWidth / 2);
   var rect = oe.getBound(oe.mouseX, oe.mouseY, oe.prevMouseX, oe.prevMouseY, r);
   oe.updateDestCanvas(rect[0], rect[1], rect[2], rect[3], true);
-  this.drawCursor(oe);
+  if (navigator.maxTouchPoints < 2){
+	this.drawCursor(oe);
+  }
 };
 
 Neo.DrawToolBase.prototype.freeHandUpMoveHandler = function (oe) {

--- a/src/tools.js
+++ b/src/tools.js
@@ -236,6 +236,7 @@ Neo.DrawToolBase.prototype.freeHandDownHandler = function (oe) {
     var rect = oe.getBound(oe.mouseX, oe.mouseY, oe.mouseX, oe.mouseY, r);
     oe.updateDestCanvas(rect[0], rect[1], rect[2], rect[3], true);
   }
+  this.drawCursor(oe);
 };
 
 Neo.DrawToolBase.prototype.freeHandUpHandler = function (oe) {
@@ -270,6 +271,7 @@ Neo.DrawToolBase.prototype.freeHandMoveHandler = function (oe) {
   var r = Math.ceil(oe.lineWidth / 2);
   var rect = oe.getBound(oe.mouseX, oe.mouseY, oe.prevMouseX, oe.prevMouseY, r);
   oe.updateDestCanvas(rect[0], rect[1], rect[2], rect[3], true);
+  this.drawCursor(oe);
 };
 
 Neo.DrawToolBase.prototype.freeHandUpMoveHandler = function (oe) {


### PR DESCRIPTION
https://github.com/funige/neo/assets/44894014/e4fdcd9c-8e58-4d1b-89c4-8807bb8b428a

↑
オリジナルのPaintBBSの円カーソルの動作。
オリジナルのPaintBBSをひさしぶりに使ってみたところ、オリジナルのPaintBBSは描画中に円カーソルが表示されたままだとわかりました。
オリジナルの動作に近づけるために、
`freeHandMoveHandler`と`freeHandUpMoveHandler`に円カーソルを表示する  
`this.drawCursor(oe);`
を追加しました。
アプリの円カーソルをペンのタッチ時にあえて消しているHTML5のアプリもありますので、funigeさんがあえて、消えるようにしていたのかもしれません。
しかしながら、オリジナルに近づけたい、どんな些細な事でも情報が欲しいという当初の話もありましたので、プルリクエストさせていただきました。
マージするかどうかの判断はおまかせします。
また、一通りの動作確認はしましたが、
`this.drawCursor(oe);`
の追加位置が適切かどうか等、動作上の問題があるようでしたらご指摘いただければ幸いです。