### PR TITLE
サーバのPOSTの上限を超えるPOST時に動画、画像ともに投稿に失敗する問題

### DIFF
--- a/src/dictionary.js
+++ b/src/dictionary.js
@@ -60,7 +60,8 @@ Neo.dictionary = {
     "投稿に失敗。\nWAFの誤検知かもしれません。\nもう少し描いてみてください。":
       "It may be a WAF false positive.\nTry to draw a little more.",
     "ファイルが見当たりません。":"File not found",
-  },
+	"画像のみが送信されます。\nレイヤー情報は保持されません。":"Only image will be sent.\nLayer information will not be retained.",
+},
   enx: {
     やり直し: "Redo",
     元に戻す: "Undo",
@@ -121,7 +122,8 @@ Neo.dictionary = {
     "投稿に失敗。\nWAFの誤検知かもしれません。\nもう少し描いてみてください。":
       "It may be a WAF false positive.\nTry to draw a little more.",
     "ファイルが見当たりません。":"File not found.",
- },
+	"画像のみが送信されます。\nレイヤー情報は保持されません。":"Only image will be sent.\nLayer information will not be retained.",
+},
   es: {
     やり直し: "Rehacer",
     元に戻す: "Deshacer",
@@ -182,6 +184,7 @@ Neo.dictionary = {
     "投稿に失敗。\nWAFの誤検知かもしれません。\nもう少し描いてみてください。":
 	  "Puede ser un falso positivo de WAF.\nIntenta dibujar un poco más.",
     "ファイルが見当たりません。":"Archivo no encontrado.",
+	"画像のみが送信されます。\nレイヤー情報は保持されません。":"Sólo se enviará la imagen.\nNo se conservará la información de la capa.",
   },
 };
 


### PR DESCRIPTION
運営しているサイトで、投稿できるPOSTのデータサイズの上限を20MBに設定していましたが、20MBを超えるpchアニメデータが生成され、画像･動画･拡張ヘッダすべてのPOSTが失敗する問題が発生しました。
その時のサーバの設定は
```
upload_max_filesize = 20M
post_max_size = 20M

```

でした。
ここで、例えば

```
upload_max_filesize = 5M
post_max_size = 20M

```
とすれば、pchファイルが15MBでPOSTの合計が20MB以下の時はpchアニメデータだけ投稿されず、画像の投稿は成功します。
しかし、
`post_max_size = 20M`
の場合は、
`upload_max_filesize`
の設定にかかわらず、POSTの合計サイズが20MBを超えた時点でPOSTはサーバに拒絶され失敗してしまいます。

そのため、neo.jsに処理を追加し、ペイント画面にもneoに数値を渡すためのオプションを設定しました。
```
<param name="neo_max_pch" value="<?=h($max_pch)?>">
```
変数には、post_max_sizeで設定されている値を
```
$max_pch = min((int)ini_get('post_max_size'),(int)ini_get('upload_max_filesize'));
```
このように、`ini_get()`で取得してMB単位でセットしています。
さくらのレンタルサーバライトのデフォルト値であれば、  8MBになるため
```
<param name="neo_max_pch" value="8"> 
```
のように値として8がセットされ、neoに渡されます。

そして、POSTの合計サイズを計算して、サーバ側のPOST可能な上限を超えている時はpchアニメデータファイルを添付せず、画像の投稿を成功させます。
ただ、この時に、レイヤー情報が失われる事をユーザーに知らせる必要があるため

```
		if(pchFileNotAppended){
			if (window.confirm(Neo.translate("画像のみが送信されます。\nレイヤー情報は保持されません。"))) {
				postData(url, formData);
			} else {
				console.log("中止しました。");
			}
		}else{
			postData(url, formData);
		}

```
window.confirmで、レイヤー情報なしで投稿する事を説明して、OKが押された時にのみ投稿処理を行います。  
これにより、レイヤー情報が失われるとは思わずに、途中保存の上のレイヤーを黒塗りしたり白塗りしたりした画像だけが投稿されるのを防止します。

運営しているサイトではこの処理が必要だったのですが、PaintBBS オリジナルの処理という訳でもないので、マージするかどうかの判断は作者であるFunigeさんの判断になります。(当たり前ですが…)
面倒な話ばかりですみませんが、よろしくご検討ください。