### PR TITLE
パレットマトリクスのtextareaでキー入力ができない問題を修正。

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -1140,7 +1140,7 @@ Neo.submit = function (board, blob, thumbnail, thumbnail2) {
   if (Neo.config.send_header_timer == "true") {
     headerString = "timer=" + timer + "&" + headerString;
   }
-//console.log("header: " + headerString);
+//   console.log("header: " + headerString);
 
   if (Neo.config.neo_emulate_security_error == "true") {
     var securityError = false;
@@ -1177,10 +1177,10 @@ Neo.submit = function (board, blob, thumbnail, thumbnail2) {
 		}
 	  if (thumbnail2) {
 		if (!Neo.config.neo_max_pch || isNaN(parseInt(Neo.config.neo_max_pch)) || ((parseInt(Neo.config.neo_max_pch)*1024*1024) > (headerString.length+blob.size+thumbnail_size+thumbnail2.size))) {
-		  formData.append('pch',thumbnail2,blob);
-		  }else{
-			  pchFileNotAppended = true;
-		  }
+			formData.append('pch',thumbnail2,blob);
+			}else{
+				pchFileNotAppended = true;
+			}
 		}
 	}
 

--- a/src/painter.js
+++ b/src/painter.js
@@ -510,14 +510,19 @@ Neo.Painter.prototype._keyDownHandler = function (e) {
   //スペース・Shift+スペースででスクロールしないように
   // if (document.activeElement != this.inputText) e.preventDefault();
   // console.log(document.activeElement.tagName)
-  if (
-    document.activeElement != this.inputText &&
-    !(document.activeElement.tagName == "INPUT")
-  ) {
-    e.preventDefault();
-  }
-};
-
+	//ctrlキーとの組み合わせのブラウザデフォルトのショートカットキーを無効化
+	//但しctrl+v,ctrl+x,ctrl+aは使用可能
+	const keys = ["+",";","=","-","s","h","r","y","z","u"];
+	if ((e.ctrlKey||e.metaKey) && keys.includes(e.key.toLowerCase())){
+		e.preventDefault();
+	}
+	//text入力と、入力フォーム以外はすべてのキーボードイベントを無効化
+	if(document.activeElement != this.inputText){
+		if (!(document.activeElement.tagName.toLocaleUpperCase() === "INPUT" || document.activeElement.tagName.toLocaleUpperCase() === "TEXTAREA")) {
+		e.preventDefault();
+		}
+	}
+}
 Neo.Painter.prototype._keyUpHandler = function (e) {
   this.isShiftDown = e.shiftKey;
   this.isCtrlDown = e.ctrlKey;


### PR DESCRIPTION
![image](https://github.com/satopian/Petit_Note/assets/44894014/8b5ec588-def4-4950-97b2-d4d381f75831)

2024年に動的パレットのデータの取得や貼り付けを使っている人はそれほど多くいないとは思いますが、これが使えると自分専用のパレットをどこの掲示板でも使えるようになります。  
そのためパレットデータの入力欄のキー入力を可能にします。
オリジナルのPaintBBSのようにctrl+v(貼り付け)crtl+x(切り取り)ctrl+c(コピー)crtl+a(すべて選択)等がパレットデータ入力欄で使用できるようにします。

また、NEOの文字入力機能使用時に全キー入力が許可されてしまい、ctrl+r(リロード)crtl+h(履歴)ctrl++(拡大)ctrl+-(縮小)のブラウザデフォルトのショートカットキーが作動してしまう問題を修正します。 
