### PR TITLE
{passive: false}を明示的に指定。

### DIFF
--- a/dist/PaintBBS-1.6.3.js
+++ b/dist/PaintBBS-1.6.3.js
@@ -2021,21 +2021,24 @@ Neo.Painter.prototype._initCanvas = function (div, width, height) {
       function (e) {
         ref._mouseDownHandler(e);
       },
-      false
+	  { passive: false,
+		capture: false }
     );
     container.addEventListener(
       "touchmove",
       function (e) {
         ref._mouseMoveHandler(e);
       },
-      false
+	  { passive: false,
+		capture: false }
     );
     container.addEventListener(
       "touchend",
       function (e) {
         ref._mouseUpHandler(e);
       },
-      false
+	  { passive: false,
+		capture: false }
     );
 
     document.onkeydown = function (e) {
@@ -7223,15 +7226,17 @@ Neo.Button.prototype.init = function (name, params) {
       ref._mouseDownHandler(e);
       e.preventDefault();
     },
-    true
-  );
+	{ passive: false,
+		capture: true }
+	  );
   this.element.addEventListener(
     "touchend",
     function (e) {
       ref._mouseUpHandler(e);
     },
-    true
-  );
+	{ passive: false,
+		capture: true }
+	  );
 
   this.element.className = !this.params.type == "fill" ? "button" : "buttonOff";
 
@@ -7389,8 +7394,9 @@ Neo.ColorTip.prototype.init = function (name, params) {
       ref._mouseDownHandler(e);
       e.preventDefault();
     },
-    true
-  );
+	{ passive: false,
+		capture: true }
+	  );
   this.element.addEventListener(
     "touchend",
     function (e) {
@@ -7524,8 +7530,9 @@ Neo.ToolTip.prototype.init = function (name, params) {
       ref._mouseDownHandler(e);
       e.preventDefault();
     },
-    true
-  );
+	{ passive: false,
+		capture: true }
+	  );
   this.element.addEventListener(
     "touchend",
     function (e) {
@@ -8384,7 +8391,8 @@ Neo.LayerControl.prototype.init = function (name, params) {
       ref._mouseDownHandler(e);
       e.preventDefault();
     },
-    true
+	{ passive: false,
+		capture: true }
   );
 
   this.element.className = "layerControl";
@@ -8465,7 +8473,8 @@ Neo.ReserveControl.prototype.init = function (name, params) {
       ref._mouseDownHandler(e);
       e.preventDefault();
     },
-    true
+	{ passive: false,
+		capture: true }
   );
 
   this.element.className = "reserve";
@@ -8669,7 +8678,8 @@ Neo.ViewerBar.prototype.init = function (name, params) {
       ref._touchHandler(e);
       e.preventDefault();
     },
-    true
+	{ passive: false,
+		capture: true }
   );
 
   this.update();

--- a/dist/neo.js
+++ b/dist/neo.js
@@ -2021,21 +2021,24 @@ Neo.Painter.prototype._initCanvas = function (div, width, height) {
       function (e) {
         ref._mouseDownHandler(e);
       },
-      false
+	  { passive: false,
+		capture: false }
     );
     container.addEventListener(
       "touchmove",
       function (e) {
         ref._mouseMoveHandler(e);
       },
-      false
+	  { passive: false,
+		capture: false }
     );
     container.addEventListener(
       "touchend",
       function (e) {
         ref._mouseUpHandler(e);
       },
-      false
+	  { passive: false,
+		capture: false }
     );
 
     document.onkeydown = function (e) {
@@ -7223,15 +7226,17 @@ Neo.Button.prototype.init = function (name, params) {
       ref._mouseDownHandler(e);
       e.preventDefault();
     },
-    true
-  );
+	{ passive: false,
+		capture: true }
+	  );
   this.element.addEventListener(
     "touchend",
     function (e) {
       ref._mouseUpHandler(e);
     },
-    true
-  );
+	{ passive: false,
+		capture: true }
+	  );
 
   this.element.className = !this.params.type == "fill" ? "button" : "buttonOff";
 
@@ -7389,8 +7394,9 @@ Neo.ColorTip.prototype.init = function (name, params) {
       ref._mouseDownHandler(e);
       e.preventDefault();
     },
-    true
-  );
+	{ passive: false,
+		capture: true }
+	  );
   this.element.addEventListener(
     "touchend",
     function (e) {
@@ -7524,8 +7530,9 @@ Neo.ToolTip.prototype.init = function (name, params) {
       ref._mouseDownHandler(e);
       e.preventDefault();
     },
-    true
-  );
+	{ passive: false,
+		capture: true }
+	  );
   this.element.addEventListener(
     "touchend",
     function (e) {
@@ -8384,7 +8391,8 @@ Neo.LayerControl.prototype.init = function (name, params) {
       ref._mouseDownHandler(e);
       e.preventDefault();
     },
-    true
+	{ passive: false,
+		capture: true }
   );
 
   this.element.className = "layerControl";
@@ -8465,7 +8473,8 @@ Neo.ReserveControl.prototype.init = function (name, params) {
       ref._mouseDownHandler(e);
       e.preventDefault();
     },
-    true
+	{ passive: false,
+		capture: true }
   );
 
   this.element.className = "reserve";
@@ -8669,7 +8678,8 @@ Neo.ViewerBar.prototype.init = function (name, params) {
       ref._touchHandler(e);
       e.preventDefault();
     },
-    true
+	{ passive: false,
+		capture: true }
   );
 
   this.update();

--- a/src/painter.js
+++ b/src/painter.js
@@ -337,21 +337,24 @@ Neo.Painter.prototype._initCanvas = function (div, width, height) {
       function (e) {
         ref._mouseDownHandler(e);
       },
-      false
+	  { passive: false,
+		capture: false }
     );
     container.addEventListener(
       "touchmove",
       function (e) {
         ref._mouseMoveHandler(e);
       },
-      false
+	  { passive: false,
+		capture: false }
     );
     container.addEventListener(
       "touchend",
       function (e) {
         ref._mouseUpHandler(e);
       },
-      false
+	  { passive: false,
+		capture: false }
     );
 
     document.onkeydown = function (e) {

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -47,15 +47,17 @@ Neo.Button.prototype.init = function (name, params) {
       ref._mouseDownHandler(e);
       e.preventDefault();
     },
-    true
-  );
+	{ passive: false,
+		capture: true }
+	  );
   this.element.addEventListener(
     "touchend",
     function (e) {
       ref._mouseUpHandler(e);
     },
-    true
-  );
+	{ passive: false,
+		capture: true }
+	  );
 
   this.element.className = !this.params.type == "fill" ? "button" : "buttonOff";
 
@@ -213,8 +215,9 @@ Neo.ColorTip.prototype.init = function (name, params) {
       ref._mouseDownHandler(e);
       e.preventDefault();
     },
-    true
-  );
+	{ passive: false,
+		capture: true }
+	  );
   this.element.addEventListener(
     "touchend",
     function (e) {
@@ -348,8 +351,9 @@ Neo.ToolTip.prototype.init = function (name, params) {
       ref._mouseDownHandler(e);
       e.preventDefault();
     },
-    true
-  );
+	{ passive: false,
+		capture: true }
+	  );
   this.element.addEventListener(
     "touchend",
     function (e) {
@@ -1208,7 +1212,8 @@ Neo.LayerControl.prototype.init = function (name, params) {
       ref._mouseDownHandler(e);
       e.preventDefault();
     },
-    true
+	{ passive: false,
+		capture: true }
   );
 
   this.element.className = "layerControl";
@@ -1289,7 +1294,8 @@ Neo.ReserveControl.prototype.init = function (name, params) {
       ref._mouseDownHandler(e);
       e.preventDefault();
     },
-    true
+	{ passive: false,
+		capture: true }
   );
 
   this.element.className = "reserve";
@@ -1493,7 +1499,8 @@ Neo.ViewerBar.prototype.init = function (name, params) {
       ref._touchHandler(e);
       e.preventDefault();
     },
-    true
+	{ passive: false,
+		capture: true }
   );
 
   this.update();


### PR DESCRIPTION
![Screen-2024-02-23_13-15-34](https://github.com/funige/neo/assets/44894014/77eb9bf3-ec2f-4db7-8e81-838de3a4f38c)

Chromeのコンソールに、36件の

>[Violation] Added non-passive event listener to a scroll-blocking

の警告が表示されるため、{passive: false}を明示的に指定しました。
Chromeの警告の内容は、{passive: true}として、Defaultの動作をキャンセルしない事をブラウザにあらかじめ伝えると高速に処理できるというものなので、Defaultの動作をキャンセルしていたり、キャンセルする可能性のある箇所に{passive: false}を指定しても処理速度が向上するわけでは無い筈なのですが、この指定によりChromeの警告を消す事はできました。
もとからイベントリスナーに入っていたtrue/falseの引数は、`capture`であるため、
```

  { passive: false,
	capture: false }

```
のようにまとめ、元の記述がtrueの場合は`capture: true`として、同じ指定になるようにしました。