### PR TITLE
ブラウザデフォルトのショートカットキー｢ctrl+o｣を無効化。

### DIFF
--- a/dist/PaintBBS-1.6.3.js
+++ b/dist/PaintBBS-1.6.3.js
@@ -2199,7 +2199,7 @@ Neo.Painter.prototype._keyDownHandler = function (e) {
   // console.log(document.activeElement.tagName)
 	//ctrlキーとの組み合わせのブラウザデフォルトのショートカットキーを無効化
 	//但しctrl+v,ctrl+x,ctrl+aは使用可能
-	const keys = ["+",";","=","-","s","h","r","y","z","u"];
+	const keys = ["+",";","=","-","s","h","r","y","z","u","o"];
 	if ((e.ctrlKey||e.metaKey) && keys.includes(e.key.toLowerCase())){
 		e.preventDefault();
 	}

--- a/dist/neo.js
+++ b/dist/neo.js
@@ -2199,7 +2199,7 @@ Neo.Painter.prototype._keyDownHandler = function (e) {
   // console.log(document.activeElement.tagName)
 	//ctrlキーとの組み合わせのブラウザデフォルトのショートカットキーを無効化
 	//但しctrl+v,ctrl+x,ctrl+aは使用可能
-	const keys = ["+",";","=","-","s","h","r","y","z","u"];
+	const keys = ["+",";","=","-","s","h","r","y","z","u","o"];
 	if ((e.ctrlKey||e.metaKey) && keys.includes(e.key.toLowerCase())){
 		e.preventDefault();
 	}

--- a/src/painter.js
+++ b/src/painter.js
@@ -515,7 +515,7 @@ Neo.Painter.prototype._keyDownHandler = function (e) {
   // console.log(document.activeElement.tagName)
 	//ctrlキーとの組み合わせのブラウザデフォルトのショートカットキーを無効化
 	//但しctrl+v,ctrl+x,ctrl+aは使用可能
-	const keys = ["+",";","=","-","s","h","r","y","z","u"];
+	const keys = ["+",";","=","-","s","h","r","y","z","u","o"];
 	if ((e.ctrlKey||e.metaKey) && keys.includes(e.key.toLowerCase())){
 		e.preventDefault();
 	}


### PR DESCRIPTION
```
const keys = ["+",";","=","-","s","h","r","y","z","u","o"];
	if ((e.ctrlKey||e.metaKey) && keys.includes(e.key.toLowerCase())){
		e.preventDefault();
	}

```
NEOの文字入力と、動的パレットのテキストエリアにフォーカスしている時のブラウザデフォルトのショートカットキーのいくつかをキャンセルしています。
そこに、ctrl+oも追加して、ブラウザでファイルを開くショートカットを無効化します。  
描画中にctrl+oを使う人はほとんどいないとは思いますが、動作しなくてもいいショートカットキーを無効化して事故を減らします。