### PR TITLE
ブラウザを終了時にもデータを保存できるよいうにするためページ移動の検知を"pagehide"から"beforeunload"へ

### DIFF
--- a/dist/PaintBBS-1.6.5.js
+++ b/dist/PaintBBS-1.6.5.js
@@ -144,7 +144,8 @@ Neo.init2 = function () {
   }
 
   window.addEventListener(
-    "pagehide",
+    // "pagehide",
+    "beforeunload",//ブラウザを終了した時にも復元データを保存
     function (e) {
       if (!Neo.uploaded && Neo.painter.isDirty()) {
         Neo.painter.saveSession();

--- a/dist/neo.js
+++ b/dist/neo.js
@@ -144,7 +144,8 @@ Neo.init2 = function () {
   }
 
   window.addEventListener(
-    "pagehide",
+    // "pagehide",
+    "beforeunload",//ブラウザを終了した時にも復元データを保存
     function (e) {
       if (!Neo.uploaded && Neo.painter.isDirty()) {
         Neo.painter.saveSession();

--- a/src/container.js
+++ b/src/container.js
@@ -144,7 +144,8 @@ Neo.init2 = function () {
   }
 
   window.addEventListener(
-    "pagehide",
+    // "pagehide",
+    "beforeunload",//ブラウザを終了した時にも復元データを保存
     function (e) {
       if (!Neo.uploaded && Neo.painter.isDirty()) {
         Neo.painter.saveSession();


### PR DESCRIPTION
誤ってブラウザを全終了してしまった時にも、復元データを保存できるようにするためページ移動の検知を"pagehide"から"beforeunload"に変更しました。
Chrome、Firefox、Safariと同じWebKitエンジンのテスト環境、Flyweightで動作確認しました。