### PR TITLE
"restore"が存在しないNEOv1.4.xのPCHデータから続きを描けなくなっていたのを修正。

### DIFF
--- a/dist/neo.js
+++ b/dist/neo.js
@@ -6292,10 +6292,15 @@ Neo.ActionManager.prototype.play = function () {
   }
 
   var func;
-  if (Neo.painter.busySkipped) {
-    //アニメーションをスキップする時はrestoreのみを関数として扱う
-    func = item[0] && this[item[0]] && item[0] == "restore" ? item[0] : "dummy";
+  // restoreが存在するかどうか判定
+  //古いPCHファイルにはrestoreが存在しないためアニメーションをスキップできない
+  const hasRestore = this._items.some((item) => item[0] === "restore");
+  if (Neo.painter.busySkipped && hasRestore) {
+    // アニメーションをスキップする時はrestoreのみを関数として扱う
+    func =
+      item[0] && this[item[0]] && item[0] === "restore" ? item[0] : "dummy";
   } else {
+    // アニメーションを再生する時は全ての関数を実行する
     func = item[0] && this[item[0]] ? item[0] : "dummy";
   }
 

--- a/dist/paintbbs-1.6.11.js
+++ b/dist/paintbbs-1.6.11.js
@@ -6292,10 +6292,15 @@ Neo.ActionManager.prototype.play = function () {
   }
 
   var func;
-  if (Neo.painter.busySkipped) {
-    //アニメーションをスキップする時はrestoreのみを関数として扱う
-    func = item[0] && this[item[0]] && item[0] == "restore" ? item[0] : "dummy";
+  // restoreが存在するかどうか判定
+  //古いPCHファイルにはrestoreが存在しないためアニメーションをスキップできない
+  const hasRestore = this._items.some((item) => item[0] === "restore");
+  if (Neo.painter.busySkipped && hasRestore) {
+    // アニメーションをスキップする時はrestoreのみを関数として扱う
+    func =
+      item[0] && this[item[0]] && item[0] === "restore" ? item[0] : "dummy";
   } else {
+    // アニメーションを再生する時は全ての関数を実行する
     func = item[0] && this[item[0]] ? item[0] : "dummy";
   }
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -141,10 +141,15 @@ Neo.ActionManager.prototype.play = function () {
   }
 
   var func;
-  if (Neo.painter.busySkipped) {
-    //アニメーションをスキップする時はrestoreのみを関数として扱う
-    func = item[0] && this[item[0]] && item[0] == "restore" ? item[0] : "dummy";
+  // restoreが存在するかどうか判定
+  //古いPCHファイルにはrestoreが存在しないためアニメーションをスキップできない
+  const hasRestore = this._items.some((item) => item[0] === "restore");
+  if (Neo.painter.busySkipped && hasRestore) {
+    // アニメーションをスキップする時はrestoreのみを関数として扱う
+    func =
+      item[0] && this[item[0]] && item[0] === "restore" ? item[0] : "dummy";
   } else {
+    // アニメーションを再生する時は全ての関数を実行する
     func = item[0] && this[item[0]] ? item[0] : "dummy";
   }
 


### PR DESCRIPTION
`<PARAM NAME="neo_animation_skip" VALUE="true">`
と設定した時に、NEOv1.4.xの古いPCHデータから続きが描けなくなっていたのを修正しました。
