### PR TITLE
Touchmove時の警告を解消。

### DIFF
--- a/dist/neo.js
+++ b/dist/neo.js
@@ -2485,7 +2485,7 @@ Neo.Painter.prototype._mouseMoveHandler = function (e) {
 
   // 画面外をタップした時スクロール可能にするため
   //  console.warn("move -" + e.target.id + e.target.className)
-  if (!(e.target.className == "o" && e.type == "touchmove")) {
+  if (e.cancelable && !(e.target.className == "o" && e.type == "touchmove")) {
     e.preventDefault();
   }
 };

--- a/dist/paintbbs-1.6.24.js
+++ b/dist/paintbbs-1.6.24.js
@@ -2485,7 +2485,7 @@ Neo.Painter.prototype._mouseMoveHandler = function (e) {
 
   // 画面外をタップした時スクロール可能にするため
   //  console.warn("move -" + e.target.id + e.target.className)
-  if (!(e.target.className == "o" && e.type == "touchmove")) {
+  if (e.cancelable && !(e.target.className == "o" && e.type == "touchmove")) {
     e.preventDefault();
   }
 };

--- a/src/painter.js
+++ b/src/painter.js
@@ -679,7 +679,7 @@ Neo.Painter.prototype._mouseMoveHandler = function (e) {
 
   // 画面外をタップした時スクロール可能にするため
   //  console.warn("move -" + e.target.id + e.target.className)
-  if (!(e.target.className == "o" && e.type == "touchmove")) {
+  if (e.cancelable && !(e.target.className == "o" && e.type == "touchmove")) {
     e.preventDefault();
   }
 };


### PR DESCRIPTION
> [Intervention] Ignored attempt to cancel a touchmove event with cancelable=false, for example because scrolling is in progress and cannot be interrupted.

CancelできないTouchmoveEventのDefaultの動作をCancelしようとして警告がでていたのを修正しました。