### PR TITLE
コピーをエスケープ、右クリックでキャンセルした直後に半透明箇所が不透明になったままになる問題を修正。

### DIFF
--- a/dist/neo.js
+++ b/dist/neo.js
@@ -5308,7 +5308,7 @@ Neo.DrawToolBase.prototype.bezierUpMoveHandler = function (oe) {
   setTimeout(() => {
     this.bezierMoveHandler(oe);
     this.ticking = false;
-  }, 30);
+  }, 10);
 };
 
 Neo.DrawToolBase.prototype.bezierKeyDownHandler = function (e) {
@@ -5805,9 +5805,11 @@ Neo.EffectToolBase.prototype.moveHandler = function (oe) {
     this.endX = this.latestX;
     this.endY = this.latestY;
 
-    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
-    this.drawCursor(oe);
-
+    //ペーストの時はカーソルを描画しない
+    if (oe.tool.type != Neo.Painter.TOOLTYPE_PASTE) {
+      oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
+      this.drawCursor(oe);
+    }
     this.ticking = false;
   });
 };
@@ -6046,9 +6048,12 @@ Neo.PasteTool.prototype.moveHandler = function (oe) {
 };
 Neo.PasteTool.prototype.cancelCopy = function () {
   var oe = Neo.painter;
+  this.ticking = false;
   oe.isCopyActive = false;
-  oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
   oe.setToolByType(Neo.Painter.TOOLTYPE_COPY);
+  setTimeout(() => {
+    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
+  }, 30);
 };
 
 Neo.PasteTool.prototype.keyDownHandler = function (e) {

--- a/dist/paintbbs-1.6.32.js
+++ b/dist/paintbbs-1.6.32.js
@@ -5308,7 +5308,7 @@ Neo.DrawToolBase.prototype.bezierUpMoveHandler = function (oe) {
   setTimeout(() => {
     this.bezierMoveHandler(oe);
     this.ticking = false;
-  }, 30);
+  }, 10);
 };
 
 Neo.DrawToolBase.prototype.bezierKeyDownHandler = function (e) {
@@ -5805,9 +5805,11 @@ Neo.EffectToolBase.prototype.moveHandler = function (oe) {
     this.endX = this.latestX;
     this.endY = this.latestY;
 
-    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
-    this.drawCursor(oe);
-
+    //ペーストの時はカーソルを描画しない
+    if (oe.tool.type != Neo.Painter.TOOLTYPE_PASTE) {
+      oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
+      this.drawCursor(oe);
+    }
     this.ticking = false;
   });
 };
@@ -6046,9 +6048,12 @@ Neo.PasteTool.prototype.moveHandler = function (oe) {
 };
 Neo.PasteTool.prototype.cancelCopy = function () {
   var oe = Neo.painter;
+  this.ticking = false;
   oe.isCopyActive = false;
-  oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
   oe.setToolByType(Neo.Painter.TOOLTYPE_COPY);
+  setTimeout(() => {
+    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
+  }, 30);
 };
 
 Neo.PasteTool.prototype.keyDownHandler = function (e) {

--- a/src/tools.js
+++ b/src/tools.js
@@ -498,7 +498,7 @@ Neo.DrawToolBase.prototype.bezierUpMoveHandler = function (oe) {
   setTimeout(() => {
     this.bezierMoveHandler(oe);
     this.ticking = false;
-  }, 30);
+  }, 10);
 };
 
 Neo.DrawToolBase.prototype.bezierKeyDownHandler = function (e) {
@@ -995,9 +995,11 @@ Neo.EffectToolBase.prototype.moveHandler = function (oe) {
     this.endX = this.latestX;
     this.endY = this.latestY;
 
-    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
-    this.drawCursor(oe);
-
+    //ペーストの時はカーソルを描画しない
+    if (oe.tool.type != Neo.Painter.TOOLTYPE_PASTE) {
+      oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
+      this.drawCursor(oe);
+    }
     this.ticking = false;
   });
 };
@@ -1236,9 +1238,12 @@ Neo.PasteTool.prototype.moveHandler = function (oe) {
 };
 Neo.PasteTool.prototype.cancelCopy = function () {
   var oe = Neo.painter;
+  this.ticking = false;
   oe.isCopyActive = false;
-  oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
   oe.setToolByType(Neo.Painter.TOOLTYPE_COPY);
+  setTimeout(() => {
+    oe.updateDestCanvas(0, 0, oe.canvasWidth, oe.canvasHeight, true);
+  }, 30);
 };
 
 Neo.PasteTool.prototype.keyDownHandler = function (e) {


### PR DESCRIPTION
NEO v1.5.xの頃から存在していた、コピー操作キャンセル直後に、コピー移動中画面の不透明度100%の画像が残る問題を修正しました。
コピーする範囲を選択している時点で、選択範囲内の画像がコピー移動時の不透明度100%画像に切り替わる問題を修正しました。